### PR TITLE
## 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
+## 0.2.3
+
+- **Docs:** Added detailed examples to `README.md` for `MaterialBorder`, `MaterialOpacity`, `MaterialBreakpoint`, `MaterialIconSize`, and `MaterialZIndex`.
+- **Example:** Added a new `MotionPage` to the example app to showcase all `MaterialMotion` tokens.
+- **Example:** Updated the `OtherTokensPage` in the example app to include showcases for `MaterialBreakpoint`, `MaterialIconSize`, and `MaterialZIndex`.
+- **Refactor:** Renamed `MotionToken` to `MaterialMotionToken` for better clarity and consistency.
+- **Fix:** Removed `MaterialBorder.none` as it was redundant (equivalent to `0`).
+
 ## 0.2.2
 
 ### Changed
 
-- **Improved** `README.md` with clearer instructions and updated usage examples.
+- **Docs** `README.md` with clearer instructions and updated usage examples.
 
 ## 0.2.1
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this line to your project's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  material_design: ^0.2.2
+  material_design: ^0.2.3
 ```
 
 Then run `flutter pub get`.
@@ -150,13 +150,81 @@ AnimatedContainer(
 
 ### Other Tokens
 
-The library also includes tokens for:
+The library also includes tokens for various other UI properties.
 
-- **`MaterialBorder`**: Standard border widths (e.g., `thin`).
-- **`MaterialOpacity`**: Opacity values for states like `hover`, `focus`, and `disabledContent`.
-- **`MaterialBreakpoint`**: Breakpoints for responsive layouts (`compact`, `medium`, `expanded`, etc.).
-- **`MaterialIconSize`**: Standard icon size (`standard` = 24dp).
-- **`MaterialZIndex`**: Conventional z-index values for layering (`content`, `floating`, `modal`, etc.).
+- **`MaterialBorder`**: Standard border widths.
+
+  - `thin` (1dp)
+
+  **Example:**
+
+  ```dart
+  Container(
+    decoration: BoxDecoration(
+      border: Border.all(width: MaterialBorder.thin),
+    ),
+  )
+  ```
+
+- **`MaterialOpacity`**: Opacity values for states and elements.
+
+  - `hover` (0.08), `focus` (0.10), `pressed` (0.10), `dragged` (0.16)
+  - `disabledContent` (0.38), `disabledContainer` (0.12)
+
+  **Example:**
+
+  ```dart
+  Container(
+    color: Colors.black.withOpacity(MaterialOpacity.hover),
+  )
+  ```
+
+- **`MaterialBreakpoint`**: Breakpoints for responsive layouts.
+
+  - `compact` (0), `medium` (600), `expanded` (840), `large` (1200), `extraLarge` (1600)
+
+  **Example:**
+
+  ```dart
+  final screenWidth = MediaQuery.of(context).size.width;
+  if (screenWidth >= MaterialBreakpoint.medium) {
+    // Use a two-column layout
+  }
+  ```
+
+- **`MaterialIconSize`**: Standard icon size.
+
+  - `standard` (24dp)
+
+  **Example:**
+
+  ```dart
+  Icon(
+    Icons.favorite,
+    size: MaterialIconSize.standard,
+  )
+  ```
+
+- **`MaterialZIndex`**: Conventional z-index values for layering.
+
+  - `content` (1), `floating` (10), `drawer` (100), `modal` (1000), `snackbar` (2000), `tooltip` (9999)
+
+  **Example:**
+
+  ```dart
+  Stack(
+    children: [
+      Positioned(
+        zIndex: MaterialZIndex.content,
+        child: Text('Content'),
+      ),
+      Positioned(
+        zIndex: MaterialZIndex.floating,
+        child: FloatingActionButton(onPressed: () {}),
+      ),
+    ],
+  )
+  ```
 
 ## Example App
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:material_design/material_design.dart';
+import 'package:material_design_example/showcase_pages/motion_page.dart';
 import 'package:provider/provider.dart';
 
 import 'color_picker.dart';
@@ -54,6 +55,7 @@ class _ShowcaseHomePageState extends State<ShowcaseHomePage> {
     const ShapePage(),
     const ElevationPage(),
     const SpacingPage(),
+    const MotionPage(),
     const OtherTokensPage(),
   ];
 
@@ -121,6 +123,10 @@ class _ShowcaseHomePageState extends State<ShowcaseHomePage> {
       const NavigationDrawerDestination(
         icon: Icon(Icons.space_bar_outlined),
         label: Text('Spacing'),
+      ),
+      const NavigationDrawerDestination(
+        icon: Icon(Icons.animation),
+        label: Text('Motion'),
       ),
       const NavigationDrawerDestination(
         icon: Icon(Icons.token_outlined),

--- a/example/lib/showcase_pages/motion_page.dart
+++ b/example/lib/showcase_pages/motion_page.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:material_design/material_design.dart';
+
+class MotionPage extends StatelessWidget {
+  const MotionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Motion')),
+      body: ListView(
+        padding: const EdgeInsets.all(MaterialSpacing.space24),
+        children: const [
+          _MotionShowcase(
+            title: 'Emphasized',
+            motionToken: MaterialMotion.emphasized,
+          ),
+          _MotionShowcase(
+            title: 'Emphasized Incoming',
+            motionToken: MaterialMotion.emphasizedIncoming,
+          ),
+          _MotionShowcase(
+            title: 'Emphasized Outgoing',
+            motionToken: MaterialMotion.emphasizedOutgoing,
+          ),
+          _MotionShowcase(
+            title: 'Standard',
+            motionToken: MaterialMotion.standard,
+          ),
+          _MotionShowcase(
+            title: 'Standard Incoming',
+            motionToken: MaterialMotion.standardIncoming,
+          ),
+          _MotionShowcase(
+            title: 'Standard Outgoing',
+            motionToken: MaterialMotion.standardOutgoing,
+          ),
+          _MotionShowcase(
+            title: 'Linear',
+            motionToken: MaterialMotion.linear,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MotionShowcase extends StatefulWidget {
+  const _MotionShowcase({
+    required this.title,
+    required this.motionToken,
+  });
+
+  final String title;
+  final MaterialMotionToken motionToken;
+
+  @override
+  State<_MotionShowcase> createState() => _MotionShowcaseState();
+}
+
+class _MotionShowcaseState extends State<_MotionShowcase>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: widget.motionToken.duration,
+      vsync: this,
+    );
+    _animation = widget.motionToken
+        .asTween(begin: 0.0, end: 1.0)
+        .animate(_controller);
+    _controller.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: MaterialSpacing.space16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(widget.title, style: MaterialTypeScale.titleMedium),
+          const SizedBox(height: MaterialSpacing.space8),
+          AnimatedBuilder(
+            animation: _animation,
+            builder: (context, child) {
+              return CustomPaint(
+                painter: _MotionPainter(
+                  animationValue: _animation.value,
+                  curve: widget.motionToken.curve,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                child: SizedBox(
+                  height: 100,
+                  width: double.infinity,
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MotionPainter extends CustomPainter {
+  _MotionPainter({
+    required this.animationValue,
+    required this.curve,
+    required this.color,
+  });
+
+  final double animationValue;
+  final Curve curve;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color.withOpacity(0.5)
+      ..strokeWidth = 2.0
+      ..style = PaintingStyle.stroke;
+
+    final path = Path();
+    path.moveTo(0, size.height);
+
+    for (double t = 0; t <= 1.0; t += 0.01) {
+      final y = size.height - curve.transform(t) * size.height;
+      path.lineTo(t * size.width, y);
+    }
+    canvas.drawPath(path, paint);
+
+    final circlePaint = Paint()..color = color;
+    final circleX = animationValue * size.width;
+    final circleY = size.height - curve.transform(animationValue) * size.height;
+    canvas.drawCircle(Offset(circleX, circleY), 6, circlePaint);
+  }
+
+  @override
+  bool shouldRepaint(_MotionPainter oldDelegate) {
+    return animationValue != oldDelegate.animationValue;
+  }
+}

--- a/example/lib/showcase_pages/other_tokens_page.dart
+++ b/example/lib/showcase_pages/other_tokens_page.dart
@@ -14,8 +14,113 @@ class OtherTokensPage extends StatelessWidget {
           _buildBorderSection(context),
           const SizedBox(height: MaterialSpacing.space32),
           _buildOpacitySection(context),
+          const SizedBox(height: MaterialSpacing.space32),
+          _buildBreakpointSection(context),
+          const SizedBox(height: MaterialSpacing.space32),
+          _buildIconSizeSection(context),
+          const SizedBox(height: MaterialSpacing.space32),
+          _buildZIndexSection(context),
         ],
       ),
+    );
+  }
+
+  Widget _buildBreakpointSection(BuildContext context) {
+    final breakpoints = [
+      ('Compact', MaterialBreakpoint.compact),
+      ('Medium', MaterialBreakpoint.medium),
+      ('Expanded', MaterialBreakpoint.expanded),
+      ('Large', MaterialBreakpoint.large),
+      ('Extra Large', MaterialBreakpoint.extraLarge),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Breakpoints', style: MaterialTypeScale.titleLarge),
+        const SizedBox(height: MaterialSpacing.space16),
+        Wrap(
+          spacing: MaterialSpacing.space16,
+          runSpacing: MaterialSpacing.space16,
+          children: breakpoints.map((breakpoint) {
+            final (label, value) = breakpoint;
+            return Chip(
+              label: Text('$label (${value.toInt()}dp)'),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildIconSizeSection(BuildContext context) {
+    final iconSizes = [
+      ('Standard', MaterialIconSize.standard),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Icon Sizes', style: MaterialTypeScale.titleLarge),
+        const SizedBox(height: MaterialSpacing.space16),
+        Wrap(
+          spacing: MaterialSpacing.space16,
+          runSpacing: MaterialSpacing.space16,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: iconSizes.map((iconSize) {
+            final (label, value) = iconSize;
+            return Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.favorite, size: value),
+                const SizedBox(width: MaterialSpacing.space8),
+                Text('$label (${value.toInt()}dp)'),
+              ],
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildZIndexSection(BuildContext context) {
+    final zIndexes = [
+      ('Content', MaterialZIndex.content),
+      ('Floating', MaterialZIndex.floating),
+      ('Drawer', MaterialZIndex.drawer),
+      ('Modal', MaterialZIndex.modal),
+      ('Snackbar', MaterialZIndex.snackbar),
+      ('Tooltip', MaterialZIndex.tooltip),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Z-Index', style: MaterialTypeScale.titleLarge),
+        const SizedBox(height: MaterialSpacing.space16),
+        SizedBox(
+          height: 150,
+          child: Stack(
+            children: zIndexes.map((zIndex) {
+              final (label, value) = zIndex;
+              final position = zIndexes.indexOf(zIndex) * 20.0;
+              return Positioned(
+                left: position,
+                top: position,
+                child: Container(
+                  width: 100,
+                  height: 100,
+                  color: Theme.of(context).colorScheme.primary.withOpacity(0.8),
+                  child: Center(
+                    child: Text(
+                      '$label\n(z: $value)',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+        ),
+      ],
     );
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,7 +129,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.2.3"
   meta:
     dependency: transitive
     description:

--- a/lib/src/tokens/animation/motion.dart
+++ b/lib/src/tokens/animation/motion.dart
@@ -11,9 +11,9 @@ import 'package:flutter/animation.dart';
 /// - [curve]: The easing curve that defines the rate of change over time.
 ///
 /// See: https://m3.material.io/styles/motion/easing-and-duration/tokens-specs
-class MotionToken {
+class MaterialMotionToken {
   /// Creates a motion token with a specific duration and curve.
-  const MotionToken(this.duration, this.curve);
+  const MaterialMotionToken(this.duration, this.curve);
 
   /// The total time the animation will take.
   final Duration duration;
@@ -42,7 +42,7 @@ class MotionToken {
 /// consistent and natural-feeling animations across the application.
 ///
 /// Instead of using fixed durations, M3 motion is defined by a combination of
-/// duration and an easing curve, represented here by the [MotionToken] class.
+/// duration and an easing curve, represented here by the [MaterialMotionToken] class.
 ///
 /// See: https://m3.material.io/styles/motion/easing-and-duration/applying-easing-and-duration
 abstract final class MaterialMotion {
@@ -51,21 +51,21 @@ abstract final class MaterialMotion {
 
   /// Emphasized easing for elements that are on-screen at the start and end.
   /// Duration: 500ms. Curve: Emphasized.
-  static const MotionToken emphasized = MotionToken(
+  static const MaterialMotionToken emphasized = MaterialMotionToken(
     Duration(milliseconds: 500),
     Cubic(0.2, 0, 0, 1),
   );
 
   /// Emphasized easing for elements that are entering the screen.
   /// Duration: 450ms. Curve: Emphasized Decelerate.
-  static const MotionToken emphasizedIncoming = MotionToken(
+  static const MaterialMotionToken emphasizedIncoming = MaterialMotionToken(
     Duration(milliseconds: 450),
     Cubic(0.05, 0.7, 0.1, 1),
   );
 
   /// Emphasized easing for elements that are exiting the screen.
   /// Duration: 200ms. Curve: Emphasized Accelerate.
-  static const MotionToken emphasizedOutgoing = MotionToken(
+  static const MaterialMotionToken emphasizedOutgoing = MaterialMotionToken(
     Duration(milliseconds: 200),
     Cubic(0.3, 0, 0.8, 0.15),
   );
@@ -75,21 +75,21 @@ abstract final class MaterialMotion {
 
   /// Standard easing for elements that are on-screen at the start and end.
   /// Duration: 300ms. Curve: Standard.
-  static const MotionToken standard = MotionToken(
+  static const MaterialMotionToken standard = MaterialMotionToken(
     Duration(milliseconds: 300),
     Cubic(0.2, 0, 0, 1),
   );
 
   /// Standard easing for elements that are entering the screen.
   /// Duration: 250ms. Curve: Standard Decelerate.
-  static const MotionToken standardIncoming = MotionToken(
+  static const MaterialMotionToken standardIncoming = MaterialMotionToken(
     Duration(milliseconds: 250),
     Cubic(0, 0, 0, 1),
   );
 
   /// Standard easing for elements that are exiting the screen.
   /// Duration: 150ms. Curve: Standard Accelerate.
-  static const MotionToken standardOutgoing = MotionToken(
+  static const MaterialMotionToken standardOutgoing = MaterialMotionToken(
     Duration(milliseconds: 150),
     Cubic(0.3, 0, 1, 1),
   );
@@ -99,7 +99,7 @@ abstract final class MaterialMotion {
 
   /// A linear interpolation curve.
   /// Duration: 200ms. Curve: Linear.
-  static const MotionToken linear = MotionToken(
+  static const MaterialMotionToken linear = MaterialMotionToken(
     Duration(milliseconds: 200),
     Curves.linear,
   );

--- a/lib/src/tokens/painting/border.dart
+++ b/lib/src/tokens/painting/border.dart
@@ -7,9 +7,6 @@
 /// This class provides a set of conventional widths to ensure consistency
 /// when creating bordered components.
 abstract final class MaterialBorder {
-  /// No border width.
-  static const double none = 0;
-
   /// The standard thin border width (1dp).
   ///
   /// This is the default for most components like `OutlinedButton`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_design
 description: "The fastest path to consistent Material Design UIs in Flutter. Build beautiful apps aligned with official metrics and guidelines using a powerful set of ready-to-use design tokens and helper widgets."
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/fluttely/material_design
 repository: https://github.com/fluttely/material_design
 


### PR DESCRIPTION
- **Docs:** Added detailed examples to `README.md` for `MaterialBorder`, `MaterialOpacity`, `MaterialBreakpoint`, `MaterialIconSize`, and `MaterialZIndex`.
- **Example:** Added a new `MotionPage` to the example app to showcase all `MaterialMotion` tokens.
- **Example:** Updated the `OtherTokensPage` in the example app to include showcases for `MaterialBreakpoint`, `MaterialIconSize`, and `MaterialZIndex`.
- **Refactor:** Renamed `MotionToken` to `MaterialMotionToken` for better clarity and consistency.
- **Fix:** Removed `MaterialBorder.none` as it was redundant (equivalent to `0`).