### PR TITLE
## 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1
+
+- **BREAKING**: Renamed `M3Opacity` to `M3StateLayerOpacity` to better reflect its purpose.
+- **feat**: Added `LaunchURLText` widget to the example app for styled URL links.
+- **feat**: Added `M3StateLayerOpacityButtonExample` to demonstrate state layer opacity on a custom button.
+- **refactor**: Updated the example app to consistently use `Theme.of(context).textTheme` for typography.
+- **docs**: Updated `README.md` with the latest changes and examples.
+
 ## 0.4.0
 
 - **BREAKING**: `M3Motion` has been refactored into `M3MotionDuration` and `M3MotionEasing` to better align with the Material Design 3 specifications.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Material Design
+# Material Design 3 Only
 
 [![pub version](https://img.shields.io/pub/v/material_design.svg)](https://pub.dev/packages/material_design)
 [![license](https://img.shields.io/badge/license-BSD-blue.svg)](/LICENSE)
@@ -13,7 +13,7 @@ Add this line to your project's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  material_design: ^0.4.0
+  material_design: ^0.4.1
 ```
 
 Then run `flutter pub get`.
@@ -99,7 +99,7 @@ Container(
 )
 ```
 
-### Elevation & Shadow
+### Elevation
 
 Use elevation tokens for surface depth and shadow tokens for casting shadows.
 
@@ -109,12 +109,17 @@ Use elevation tokens for surface depth and shadow tokens for casting shadows.
 **Example:**
 
 ```dart
+final useShadow = true;
+final elevation = M3Elevation.level5;
+final elevationSurfaceColor = M3TonalColor.fromElevation(context, elevation);
+final elevationShadows = useShadow ? M3Shadow.fromElevation(elevation) : <BoxShadow>[];
 Container(
   decoration: ShapeDecoration(
-    shape: M3Shape.medium,
-    shadows: M3Shadow.level2, // 3dp elevation shadow
+    shape: M3Shape.small,
+    color: elevationSurfaceColor,
+    shadows: elevationShadows,
   ),
-)
+),
 ```
 
 ### Spacing
@@ -185,7 +190,7 @@ The library also includes tokens for various other UI properties.
   )
   ```
 
-- **`M3Opacity`**: Opacity values for states and elements.
+- **`M3StateLayerOpacity`**: Opacity values for states and elements.
 
   - `hover` (0.08), `focus` (0.10), `pressed` (0.10), `dragged` (0.16)
   - `disabledContent` (0.38), `disabledContainer` (0.12)
@@ -193,8 +198,9 @@ The library also includes tokens for various other UI properties.
   **Example:**
 
   ```dart
+  final isHoreved = M3StateLayerOpacity.hover ? null;
   Container(
-    color: Colors.black.withValues(alpha: M3Opacity.hover),
+    color: Colors.black.withValues(alpha: M3StateLayerOpacity.hover),
   )
   ```
 

--- a/example/.metadata
+++ b/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "077b4a4ce10a07b82caa6897f0c626f9c0a3ac90"
+  revision: "d7b523b356d15fb81e7d340bbe52b47f93937323"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-    - platform: android
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-    - platform: ios
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-    - platform: linux
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-    - platform: macos
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
+      create_revision: d7b523b356d15fb81e7d340bbe52b47f93937323
+      base_revision: d7b523b356d15fb81e7d340bbe52b47f93937323
     - platform: web
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-    - platform: windows
-      create_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
-      base_revision: 077b4a4ce10a07b82caa6897f0c626f9c0a3ac90
+      create_revision: d7b523b356d15fb81e7d340bbe52b47f93937323
+      base_revision: d7b523b356d15fb81e7d340bbe52b47f93937323
 
   # User provided section
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:material_design/material_design.dart';
 import 'package:material_design_example/showcase_pages/motion_page.dart';
+import 'package:material_design_example/showcase_pages/widgets/launch_url_text.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'color_picker.dart';
 import 'showcase_pages/color_page.dart';
@@ -236,47 +236,32 @@ class _ShowcaseHomePageState extends State<ShowcaseHomePage> {
             ],
           ),
         ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: M3Spacing.space16),
+          child: Row(
+            children: [
+              LaunchURLText(
+                title: 'M3 Components',
+                m3Url: 'https://flutterweb-wasm.web.app/',
+              ),
+            ],
+          ),
+        ),
       ],
     );
   }
 
   Widget _buildScrollableNavigationRail(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
-    final m3Url = 'https://m3.material.io/';
     return Container(
       width: 80,
       color: Theme.of(context).colorScheme.surface,
       child: Column(
         children: [
-          Tooltip(
-            // 1. O texto que aparecerá no tooltip
-            message: m3Url,
-            child: InkWell(
-              // 2. A função que será chamada ao clicar
-              onTap: () async {
-                await launchUrl(
-                  Uri.parse(m3Url),
-                  // Este parâmetro garante que o link abra em uma nova aba no navegador
-                  webOnlyWindowName: '_blank',
-                );
-              },
-              child: Container(
-                height: 56,
-                alignment: Alignment.center,
-                // O seu widget original permanece aqui
-                child: Text(
-                  'M3',
-                  // Opcional: Adicionar um estilo para parecer um link
-                  style: M3TypeScale.titleMedium.copyWith(
-                    color: Colors.blue,
-                    decoration: TextDecoration.underline,
-                    decorationColor: Colors.blue,
-                  ),
-                ),
-              ),
-            ),
+          LaunchURLText(
+            title: 'M3',
+            m3Url: 'https://m3.material.io/',
           ),
-
           Expanded(
             child: SingleChildScrollView(
               child: Column(
@@ -298,12 +283,14 @@ class _ShowcaseHomePageState extends State<ShowcaseHomePage> {
                       },
                     );
                   }),
-
-                  const SizedBox(height: M3Spacing.space16),
-
-                  const Divider(height: 20, indent: 8, endIndent: 8),
-                  const SizedBox(height: M3Spacing.space12),
-
+                  const Divider(
+                    indent: M3Spacing.space8,
+                    endIndent: M3Spacing.space8,
+                  ),
+                  LaunchURLText(
+                    title: 'Demo',
+                    m3Url: 'https://flutterweb-wasm.web.app/',
+                  ),
                   Switch(
                     value: themeProvider.themeMode == ThemeMode.dark,
                     onChanged: (isDark) {
@@ -313,8 +300,7 @@ class _ShowcaseHomePageState extends State<ShowcaseHomePage> {
                     },
                   ),
                   const Text('Dark Mode', style: TextStyle(fontSize: 12)),
-                  const SizedBox(height: M3Spacing.space20),
-
+                  const SizedBox(height: M3Spacing.space16),
                   IconButton(
                     icon: Icon(
                       Icons.color_lens,

--- a/example/lib/showcase_pages/color_page.dart
+++ b/example/lib/showcase_pages/color_page.dart
@@ -7,6 +7,7 @@ class ColorPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     final keyColors = [
       (
@@ -165,7 +166,7 @@ class ColorPage extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Key Colors', style: M3TypeScale.titleLarge),
+                  Text('Key Colors', style: textTheme.titleLarge),
                   const SizedBox(height: M3Spacing.space16),
                   ...keyColors.map(
                     (p) =>
@@ -180,7 +181,7 @@ class ColorPage extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Scheme', style: M3TypeScale.titleLarge),
+                  Text('Scheme', style: textTheme.titleLarge),
                   const SizedBox(height: M3Spacing.space16),
                   Wrap(
                     spacing: M3Spacing.space8,
@@ -220,6 +221,8 @@ class _KeyColorChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Padding(
       padding: const EdgeInsets.only(bottom: M3Spacing.space8),
       child: Container(
@@ -233,11 +236,11 @@ class _KeyColorChip extends StatelessWidget {
           children: [
             Text(
               name,
-              style: M3TypeScale.titleMedium.copyWith(color: onColor),
+              style: textTheme.titleMedium?.copyWith(color: onColor),
             ),
             Text(
               _colorToHex(color),
-              style: M3TypeScale.bodyMedium.copyWith(color: onColor),
+              style: textTheme.bodyMedium?.copyWith(color: onColor),
             ),
           ],
         ),
@@ -262,6 +265,7 @@ class _ColorChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return Container(
       width: 150,
@@ -276,11 +280,11 @@ class _ColorChip extends StatelessWidget {
         children: [
           Text(
             name,
-            style: M3TypeScale.labelLarge.copyWith(color: onColor),
+            style: textTheme.labelLarge?.copyWith(color: onColor),
           ),
           Text(
             _colorToHex(color),
-            style: M3TypeScale.labelSmall.copyWith(color: onColor),
+            style: textTheme.labelSmall?.copyWith(color: onColor),
           ),
         ],
       ),

--- a/example/lib/showcase_pages/elevation_page.dart
+++ b/example/lib/showcase_pages/elevation_page.dart
@@ -36,6 +36,8 @@ class _ElevationShowcase extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     final elevationLevels = [
       (M3Elevation.level0, 'Level 0', '0%'),
       (M3Elevation.level1, 'Level 1', '5%'),
@@ -50,7 +52,7 @@ class _ElevationShowcase extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(title, style: M3TypeScale.titleLarge),
+          Text(title, style: textTheme.titleLarge),
           const SizedBox(height: M3Spacing.space16),
           Wrap(
             spacing: M3Spacing.space16,
@@ -60,12 +62,12 @@ class _ElevationShowcase extends StatelessWidget {
               final levelName = entry.value.$2;
               final levelPercent = entry.value.$3;
 
-              final surfaceColor = M3TonalColor.fromElevation(
+              final elevationSurfaceColor = M3TonalColor.fromElevation(
                 context,
                 elevation,
               );
 
-              final shadows = useShadow
+              final elevationShadows = useShadow
                   ? M3Shadow.fromElevation(elevation)
                   : <BoxShadow>[];
 
@@ -73,9 +75,9 @@ class _ElevationShowcase extends StatelessWidget {
                 width: double.infinity,
                 height: M3Spacing.space120,
                 decoration: ShapeDecoration(
-                  color: surfaceColor,
-                  shadows: shadows,
                   shape: M3Shape.small,
+                  color: elevationSurfaceColor,
+                  shadows: elevationShadows,
                 ),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
@@ -88,11 +90,11 @@ class _ElevationShowcase extends StatelessWidget {
                         children: [
                           Text(
                             levelName,
-                            style: M3TypeScale.labelMedium,
+                            style: textTheme.labelMedium,
                           ),
                           Text(
                             '${elevation.toStringAsFixed(0)} dp',
-                            style: M3TypeScale.bodySmall,
+                            style: textTheme.bodySmall,
                           ),
                         ],
                       ),
@@ -104,7 +106,7 @@ class _ElevationShowcase extends StatelessWidget {
                         padding: const EdgeInsets.all(M3Spacing.space8),
                         child: Text(
                           levelPercent,
-                          style: M3TypeScale.bodySmall,
+                          style: textTheme.bodySmall,
                         ),
                       ),
                     ),

--- a/example/lib/showcase_pages/motion_page.dart
+++ b/example/lib/showcase_pages/motion_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:material_design/material_design.dart';
+import 'package:material_design_example/showcase_pages/widgets/launch_url_text.dart';
 
 class MotionPage extends StatelessWidget {
   const MotionPage({super.key});
@@ -7,7 +8,13 @@ class MotionPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('M3Motion Tokens')),
+      appBar: AppBar(
+        title: LaunchURLText(
+          title: 'M3StateLayerOpacity Tokens (State Layers)',
+          m3Url:
+              'https://m3.material.io/styles/motion/easing-and-duration/applying-easing-and-duration',
+        ),
+      ),
       body: ListView(
         padding: const EdgeInsets.all(M3Spacing.space24),
         children: const [
@@ -95,13 +102,14 @@ class _MotionShowcaseState extends State<_MotionShowcase>
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: M3Spacing.space16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(widget.title, style: M3TypeScale.titleMedium),
+          Text(widget.title, style: textTheme.titleMedium),
           const SizedBox(height: M3Spacing.space8),
           AnimatedBuilder(
             animation: _animation,

--- a/example/lib/showcase_pages/other_tokens_page.dart
+++ b/example/lib/showcase_pages/other_tokens_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:material_design/material_design.dart';
+import 'package:material_design_example/showcase_pages/widgets/launch_url_text.dart';
+import 'package:material_design_example/showcase_pages/widgets/state_layer_opacity_button_example.dart';
 
 class OtherTokensPage extends StatelessWidget {
   const OtherTokensPage({super.key});
@@ -13,7 +15,7 @@ class OtherTokensPage extends StatelessWidget {
         children: [
           _buildBorderSection(context),
           const SizedBox(height: M3Spacing.space32),
-          _buildOpacitySection(context),
+          _buildStateLayerOpacitySection(context),
           const SizedBox(height: M3Spacing.space32),
           _buildBreakpointSection(context),
           const SizedBox(height: M3Spacing.space32),
@@ -26,6 +28,8 @@ class OtherTokensPage extends StatelessWidget {
   }
 
   Widget _buildBreakpointSection(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     final breakpoints = [
       ('Compact', M3Breakpoint.compact),
       ('Medium', M3Breakpoint.medium),
@@ -37,7 +41,7 @@ class OtherTokensPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('M3Breakpoint Tokens', style: M3TypeScale.titleLarge),
+        Text('M3Breakpoint Tokens', style: textTheme.titleLarge),
         const SizedBox(height: M3Spacing.space16),
         Wrap(
           spacing: M3Spacing.space16,
@@ -54,6 +58,8 @@ class OtherTokensPage extends StatelessWidget {
   }
 
   Widget _buildIconSizeSection(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     final iconSizes = [
       ('dense', M3IconSize.dense),
       ('standard', M3IconSize.standard),
@@ -65,7 +71,7 @@ class OtherTokensPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('M3IconSize Tokens', style: M3TypeScale.titleLarge),
+        Text('M3IconSize Tokens', style: textTheme.titleLarge),
         const SizedBox(height: M3Spacing.space16),
         Wrap(
           spacing: M3Spacing.space16,
@@ -89,6 +95,7 @@ class OtherTokensPage extends StatelessWidget {
 
   Widget _buildZIndexSection(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     final zIndexLayers = [
       _ZIndexLayer(
@@ -138,11 +145,11 @@ class OtherTokensPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('M3ZIndex Tokens', style: M3TypeScale.titleLarge),
+        Text('M3ZIndex Tokens', style: textTheme.titleLarge),
         const SizedBox(height: M3Spacing.space8),
         Text(
           'Stacking order from bottom to top (lower to higher z-index)',
-          style: M3TypeScale.bodyMedium.copyWith(
+          style: textTheme.bodyMedium?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
         ),
@@ -194,7 +201,7 @@ class OtherTokensPage extends StatelessWidget {
                         children: [
                           Text(
                             layer.name,
-                            style: M3TypeScale.titleSmall.copyWith(
+                            style: textTheme.titleSmall?.copyWith(
                               // color: _getTextColor(layer.color, colorScheme),
                               fontWeight: FontWeight.bold,
                             ),
@@ -202,14 +209,14 @@ class OtherTokensPage extends StatelessWidget {
                           const SizedBox(height: M3Spacing.space4),
                           Text(
                             'z: ${layer.zIndex}',
-                            style: M3TypeScale.labelMedium.copyWith(
+                            style: textTheme.labelMedium?.copyWith(
                               // color: _getTextColor(layer.color, colorScheme),
                             ),
                           ),
                           const SizedBox(height: M3Spacing.space4),
                           Text(
                             layer.description,
-                            style: M3TypeScale.bodySmall.copyWith(
+                            style: textTheme.bodySmall?.copyWith(
                               // color: _getTextColor(layer.color, colorScheme),
                             ),
                           ),
@@ -245,11 +252,11 @@ class OtherTokensPage extends StatelessWidget {
                 ),
                 title: Text(
                   layer.name,
-                  style: M3TypeScale.bodyLarge,
+                  style: textTheme.bodyLarge,
                 ),
                 subtitle: Text(
                   layer.description,
-                  style: M3TypeScale.bodyMedium.copyWith(
+                  style: textTheme.bodyMedium?.copyWith(
                     color: colorScheme.onSurfaceVariant,
                   ),
                 ),
@@ -264,7 +271,7 @@ class OtherTokensPage extends StatelessWidget {
                   ),
                   child: Text(
                     '${layer.zIndex}',
-                    style: M3TypeScale.labelMedium.copyWith(
+                    style: textTheme.labelMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
                   ),
@@ -279,6 +286,7 @@ class OtherTokensPage extends StatelessWidget {
 
   Widget _buildBorderSection(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     final borders = [
       ('Thin', M3Border.thin),
@@ -287,7 +295,7 @@ class OtherTokensPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('M3Border Tokens', style: M3TypeScale.titleLarge),
+        Text('M3Border Tokens', style: textTheme.titleLarge),
         const SizedBox(height: M3Spacing.space16),
         Wrap(
           spacing: M3Spacing.space16,
@@ -307,25 +315,27 @@ class OtherTokensPage extends StatelessWidget {
     );
   }
 
-  Widget _buildOpacitySection(BuildContext context) {
+  Widget _buildStateLayerOpacitySection(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
     final opacities = [
-      ('Hover', M3Opacity.hover),
-      ('Focus', M3Opacity.focus),
-      ('Pressed', M3Opacity.pressed),
-      ('Dragged', M3Opacity.dragged),
-      ('Disabled Content', M3Opacity.disabledContent),
-      ('Disabled Container', M3Opacity.disabledContainer),
+      ('Hover', M3StateLayerOpacity.hover),
+      ('Focus', M3StateLayerOpacity.focus),
+      ('Pressed', M3StateLayerOpacity.pressed),
+      ('Dragged', M3StateLayerOpacity.dragged),
+      ('disabledContent', M3StateLayerOpacity.disabledContent),
+      ('disabledContainer', M3StateLayerOpacity.disabledContainer),
     ];
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'M3Opacity Tokens (State Layers)',
-          style: M3TypeScale.titleLarge,
+        LaunchURLText(
+          title: 'M3StateLayerOpacity Tokens (State Layers)',
+          m3Url:
+              'https://m3.material.io/foundations/interaction/states/overview',
         ),
+        // style: textTheme.titleLarge,
         const SizedBox(height: M3Spacing.space16),
         Wrap(
           spacing: M3Spacing.space16,
@@ -348,6 +358,8 @@ class OtherTokensPage extends StatelessWidget {
             );
           }).toList(),
         ),
+        const SizedBox(height: M3Spacing.space12),
+        M3StateLayerOpacityButtonExample(),
       ],
     );
   }

--- a/example/lib/showcase_pages/shape_page.dart
+++ b/example/lib/showcase_pages/shape_page.dart
@@ -7,6 +7,7 @@ class ShapePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     final shapes = [
       ('None', M3Shape.none),
@@ -39,7 +40,7 @@ class ShapePage extends StatelessWidget {
             child: Center(
               child: Text(
                 label,
-                style: M3TypeScale.bodyLarge,
+                style: textTheme.bodyLarge,
                 textAlign: TextAlign.center,
               ),
             ),

--- a/example/lib/showcase_pages/spacing_page.dart
+++ b/example/lib/showcase_pages/spacing_page.dart
@@ -7,6 +7,7 @@ class SpacingPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     final spacings = [
       /// Material Design 3 spacing scale
@@ -71,7 +72,7 @@ class SpacingPage extends StatelessWidget {
                 width: M3Spacing.space112,
                 child: Text(
                   '$label (${height}dp):',
-                  style: M3TypeScale.bodyMedium,
+                  style: textTheme.bodyMedium,
                 ),
               ),
               const SizedBox(width: M3Spacing.space16),

--- a/example/lib/showcase_pages/widgets/launch_url_text.dart
+++ b/example/lib/showcase_pages/widgets/launch_url_text.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:material_design/material_design.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class LaunchURLText extends StatelessWidget {
+  const LaunchURLText({
+    super.key,
+    required this.title,
+    required this.m3Url,
+  });
+
+  final String title;
+  final String m3Url;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: M3Spacing.space16),
+      child: Tooltip(
+        message: m3Url,
+        child: InkWell(
+          onTap: () async {
+            await launchUrl(
+              Uri.parse(m3Url),
+              webOnlyWindowName: '_blank',
+            );
+          },
+          child: Text(
+            title,
+            style: textTheme.titleLarge?.copyWith(
+              color: Colors.blue,
+              decoration: TextDecoration.underline,
+              decorationColor: Colors.blue,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/showcase_pages/widgets/state_layer_opacity_button_example.dart
+++ b/example/lib/showcase_pages/widgets/state_layer_opacity_button_example.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:material_design/material_design.dart';
+
+class M3StateLayerOpacityButtonExample extends StatelessWidget {
+  const M3StateLayerOpacityButtonExample({super.key});
+
+  Widget _buildButtonArea({
+    required String title,
+    required void Function()? onPressed,
+  }) {
+    return Column(
+      children: [
+        Text(title),
+        const SizedBox(height: M3Spacing.space12),
+        CustomButton(
+          onPressed: onPressed,
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.add_shopping_cart),
+              SizedBox(width: M3Spacing.space8),
+              Text('Add to Cart'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      children: [
+        _buildButtonArea(title: 'Enabled State:', onPressed: () {}),
+        SizedBox(width: M3Spacing.space12),
+        _buildButtonArea(title: 'Disabled State:', onPressed: null),
+      ],
+    );
+  }
+}
+
+class CustomButton extends StatefulWidget {
+  const CustomButton({
+    super.key,
+    required this.onPressed,
+    required this.child,
+  });
+
+  final VoidCallback? onPressed;
+  final Widget child;
+
+  @override
+  State<CustomButton> createState() => _CustomButtonState();
+}
+
+class _CustomButtonState extends State<CustomButton> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  bool get _isEnabled => widget.onPressed != null;
+
+  double get _elevation {
+    if (!_isEnabled) return 0.0;
+    if (_isPressed) return 1.0;
+    if (_isHovered) return 3.0;
+    return 1.0;
+  }
+
+  double get _stateLayerOpacity {
+    if (!_isEnabled) return 0.0;
+    if (_isPressed) return M3StateLayerOpacity.pressed;
+    if (_isHovered) return M3StateLayerOpacity.hover;
+    return 0.0;
+  }
+
+  Color _getBackgroundColor(ColorScheme colorScheme) {
+    if (!_isEnabled) {
+      return colorScheme.onSurface.withValues(
+        alpha: M3StateLayerOpacity.disabledContainer,
+      );
+    }
+
+    return M3TonalColor.fromElevation(
+      context,
+      _elevation,
+    );
+  }
+
+  Color _getContentColor(ColorScheme colorScheme) {
+    if (!_isEnabled) {
+      return colorScheme.onSurface.withValues(
+        alpha: M3StateLayerOpacity.disabledContent,
+      );
+    }
+    return colorScheme.primary;
+  }
+
+  Color _getStateLayerColor(ColorScheme colorScheme) {
+    return colorScheme.primary;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colorScheme = theme.colorScheme;
+
+    final contentColor = _getContentColor(colorScheme);
+    final stateLayerColor = _getStateLayerColor(colorScheme);
+    final backgroundColor = _getBackgroundColor(colorScheme);
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      cursor: _isEnabled
+          ? SystemMouseCursors.click
+          : SystemMouseCursors.forbidden,
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _isPressed = true),
+        onTapUp: (_) => setState(() => _isPressed = false),
+        onTapCancel: () => setState(() => _isPressed = false),
+        onTap: widget.onPressed,
+        child: AnimatedContainer(
+          duration: M3MotionDuration.short3,
+          child: Material(
+            type: MaterialType.canvas,
+            elevation: _elevation,
+            color: backgroundColor,
+            shape: const StadiumBorder(),
+            clipBehavior: Clip.antiAlias,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                DefaultTextStyle(
+                  style: textTheme.labelLarge!.copyWith(
+                    color: contentColor,
+                  ),
+                  child: IconTheme(
+                    data: IconThemeData(color: contentColor, size: 18),
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: M3Spacing.space24,
+                        vertical: 6,
+                      ),
+                      child: widget.child,
+                    ),
+                  ),
+                ),
+
+                Positioned.fill(
+                  child: AnimatedContainer(
+                    duration: M3MotionDuration.short3,
+                    decoration: BoxDecoration(
+                      color: stateLayerColor.withValues(
+                        alpha: _stateLayerOpacity,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/theme_provider.dart
+++ b/example/lib/theme_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design/material_design.dart';
 
 class ThemeProvider with ChangeNotifier {
   ThemeMode _themeMode = ThemeMode.light;
@@ -12,6 +13,23 @@ class ThemeProvider with ChangeNotifier {
       seedColor: _seedColor,
       brightness: Brightness.light,
     ),
+    textTheme: TextTheme(
+      displayLarge: M3TypeScale.displayLarge,
+      displayMedium: M3TypeScale.displayMedium,
+      displaySmall: M3TypeScale.displaySmall,
+      headlineLarge: M3TypeScale.headlineLarge,
+      headlineMedium: M3TypeScale.headlineMedium,
+      headlineSmall: M3TypeScale.headlineSmall,
+      titleLarge: M3TypeScale.titleLarge,
+      titleMedium: M3TypeScale.titleMedium,
+      titleSmall: M3TypeScale.titleSmall,
+      bodyLarge: M3TypeScale.bodyLarge,
+      bodyMedium: M3TypeScale.bodyMedium,
+      bodySmall: M3TypeScale.bodySmall,
+      labelLarge: M3TypeScale.labelLarge,
+      labelMedium: M3TypeScale.labelMedium,
+      labelSmall: M3TypeScale.labelSmall,
+    ),
     useMaterial3: true,
   );
 
@@ -19,6 +37,23 @@ class ThemeProvider with ChangeNotifier {
     colorScheme: ColorScheme.fromSeed(
       seedColor: _seedColor,
       brightness: Brightness.dark,
+    ),
+    textTheme: TextTheme(
+      displayLarge: M3TypeScale.displayLarge,
+      displayMedium: M3TypeScale.displayMedium,
+      displaySmall: M3TypeScale.displaySmall,
+      headlineLarge: M3TypeScale.headlineLarge,
+      headlineMedium: M3TypeScale.headlineMedium,
+      headlineSmall: M3TypeScale.headlineSmall,
+      titleLarge: M3TypeScale.titleLarge,
+      titleMedium: M3TypeScale.titleMedium,
+      titleSmall: M3TypeScale.titleSmall,
+      bodyLarge: M3TypeScale.bodyLarge,
+      bodyMedium: M3TypeScale.bodyMedium,
+      bodySmall: M3TypeScale.bodySmall,
+      labelLarge: M3TypeScale.labelLarge,
+      labelMedium: M3TypeScale.labelMedium,
+      labelSmall: M3TypeScale.labelSmall,
     ),
     useMaterial3: true,
   );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -134,7 +134,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   meta:
     dependency: transitive
     description:

--- a/lib/src/m3/tokens/painting/m3_state_layer_opacity.dart
+++ b/lib/src/m3/tokens/painting/m3_state_layer_opacity.dart
@@ -6,9 +6,9 @@ import 'package:flutter/foundation.dart';
 /// State layers are semi-transparent overlays that indicate the state of an
 /// interactive component (e.g., hovered, focused, pressed).
 ///
-/// Reference: https://m3.material.io/styles/states/overview
+/// Reference: https://m3.material.io/foundations/interaction/states/state-layers
 @immutable
-abstract final class M3Opacity {
+abstract final class M3StateLayerOpacity {
   // --- State Layer Opacities ---
 
   /// Opacity for a hovered state layer (+8%).

--- a/lib/src/m3/tokens/tokens.dart
+++ b/lib/src/m3/tokens/tokens.dart
@@ -12,7 +12,7 @@ export 'geometry/m3_shape.dart';
 export 'geometry/m3_spacing.dart';
 export 'geometry/m3_visual_density.dart';
 export 'painting/m3_border.dart';
-export 'painting/m3_opacity.dart';
 export 'painting/m3_shadow.dart';
+export 'painting/m3_state_layer_opacity.dart';
 export 'painting/m3_z_index.dart';
 export 'typography/m3_type_scale.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_design
 description: "The fastest path to consistent Material Design UIs in Flutter. Build beautiful apps aligned with official metrics and guidelines using a powerful set of ready-to-use design tokens and helper widgets."
-version: 0.4.0
+version: 0.4.1
 # author: Kevin Kobori <https://www.linkedin.com/in/kevin-kobori/>
 homepage:
 repository: https://github.com/fluttely/material_design


### PR DESCRIPTION
- **BREAKING**: Renamed `M3Opacity` to `M3StateLayerOpacity` to better reflect its purpose.
- **feat**: Added `LaunchURLText` widget to the example app for styled URL links.
- **feat**: Added `M3StateLayerOpacityButtonExample` to demonstrate state layer opacity on a custom button.
- **refactor**: Updated the example app to consistently use `Theme.of(context).textTheme` for typography.
- **docs**: Updated `README.md` with the latest changes and examples.