### PR TITLE
## 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1
+
+- **BREAKING**: Renamed `M3Margins` to `M3Margin` and `M3Spacers` to `M3Spacer` for better naming consistency.
+- **DOCS**: Updated `README.md` to reflect the new class names and provide clearer examples.
+- **CHORE**: Updated the example app to use the new `M3Margin` and `M3Spacer` classes.
+
 ## 0.5.0
 
 - **BREAKING**: Token classes are now `abstract class` instead of `abstract final class` to allow for extension.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this line to your project's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  material_design: ^0.5.0
+  material_design: ^0.5.1
 ```
 
 Then run `flutter pub get`.
@@ -137,11 +137,11 @@ Container(
 ),
 ```
 
-### Spacing
+### Spacing & Layout
 
-A granular spacing scale for consistent layouts.
+A granular scale for consistent spacing, margins, and layouts.
 
-- **`M3Spacing`**: Provides spacing values from `none` to `space512`.
+- **`M3Spacing`**: Provides spacing values from `none` to `space128` based on a 4dp grid. Ideal for padding and small gaps between UI elements.
 
 **Example:**
 
@@ -149,6 +149,39 @@ A granular spacing scale for consistent layouts.
 Padding(
   padding: const EdgeInsets.all(M3Spacing.space16), // 16dp padding
   child: Text('Hello, Material!'),
+)
+```
+
+- **`M3Margin`**: Provides semantic margin values for the outer edges of the screen layout.
+
+  - screen (16dp) for compact/medium screens.
+
+  - screenLarge (24dp) for large/extra-large screens.
+
+**Example:**
+
+```dart
+Container(
+  margin: const EdgeInsets.symmetric(horizontal: M3Margin.screen),
+  child: Text('Content with screen margins'),
+)
+```
+
+- **`M3Spacer`**: pane (24dp) for the gap between two content panes.
+
+  - screen (16dp) for compact/medium screens.
+
+  - screenLarge (24dp) for large/extra-large screens.
+
+**Example:**
+
+```dart
+Row(
+  children: [
+    Expanded(child: ContentPane1()),
+    const SizedBox(width: M3Spacer.pane),
+    Expanded(child: ContentPane2()),
+  ],
 )
 ```
 

--- a/example/lib/showcase_pages/spacing_page.dart
+++ b/example/lib/showcase_pages/spacing_page.dart
@@ -82,15 +82,15 @@ class SpacingPage extends StatelessWidget {
     ];
 
     final margins = [
-      ('compactScreen', M3Margins.compactScreen),
-      ('mediumScreen', M3Margins.mediumScreen),
-      ('expandedScreen', M3Margins.expandedScreen),
-      ('largeScreen', M3Margins.largeScreen),
-      ('extraLargeScreen', M3Margins.extraLargeScreen),
+      ('compactScreen', M3Margin.compactScreen),
+      ('mediumScreen', M3Margin.mediumScreen),
+      ('expandedScreen', M3Margin.expandedScreen),
+      ('largeScreen', M3Margin.largeScreen),
+      ('extraLargeScreen', M3Margin.extraLargeScreen),
     ];
 
     final spacers = [
-      ('pane', M3Spacers.pane),
+      ('pane', M3Spacer.pane),
     ];
 
     return Scaffold(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.1"
   meta:
     dependency: transitive
     description:

--- a/lib/src/m3/tokens/geometry/m3_spacing.dart
+++ b/lib/src/m3/tokens/geometry/m3_spacing.dart
@@ -81,7 +81,7 @@ abstract class M3Spacing {
 ///
 /// Reference: https://m3.material.io/foundations/layout/applying-layout/pane-layouts
 @immutable
-abstract class M3Margins {
+abstract class M3Margin {
   /// https://m3.material.io/foundations/layout/applying-layout/compact
   /// The default margin for compact screen layouts (16dp).
   static const double compactScreen = 16.0;
@@ -110,7 +110,7 @@ abstract class M3Margins {
 ///
 /// Reference: https://m3.material.io/foundations/layout/understanding-layout/spacing
 @immutable
-abstract class M3Spacers {
+abstract class M3Spacer {
   /// The standard width of a spacer between two content panes (24dp).
   static const double pane = 24.0;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_design
 description: "The fastest path to consistent Material Design UIs in Flutter. Build beautiful apps aligned with official metrics and guidelines using a powerful set of ready-to-use design tokens and helper widgets."
-version: 0.5.0
+version: 0.5.1
 # author: Kevin Kobori <https://www.linkedin.com/in/kevin-kobori/>
 homepage:
 repository: https://github.com/fluttely/material_design


### PR DESCRIPTION
- **BREAKING**: Renamed `M3Margins` to `M3Margin` and `M3Spacers` to `M3Spacer` for better naming consistency.
- **DOCS**: Updated `README.md` to reflect the new class names and provide clearer examples.
- **CHORE**: Updated the example app to use the new `M3Margin` and `M3Spacer` classes.